### PR TITLE
Syntax change / unification for first booster

### DIFF
--- a/CSV/Language/English/Card/10.txt
+++ b/CSV/Language/English/Card/10.txt
@@ -1,3 +1,3 @@
 default
 魔導の研究者,Magic Researcher
-[1].このカードが召喚・特殊召喚に成功したとき発動する。このカードの攻撃力と最大HPは、自分の墓地にある魔法カードの数×50ポイントアップする。,[1]. When this card is normal or special summoned; increase its ATK and MAX HP by 50 for each Spell Card in your graveyard.
+[1].このカードが召喚・特殊召喚に成功したとき発動する。このカードの攻撃力と最大HPは、自分の墓地にある魔法カードの数×50ポイントアップする。,[1]. When this card is Summoned: This cards gains 50 x X ATK and MAX HP (X = number of Spell Cards in your Graveyard).

--- a/CSV/Language/English/Card/12.txt
+++ b/CSV/Language/English/Card/12.txt
@@ -1,3 +1,4 @@
 default
 デーモンスレイヤー,Demon Slayer
-[1].このカードが悪魔タイプのモンスターまたは「サキュバス」モンスターへ与える戦闘ダメージは倍になる。\n[2].悪魔タイプのモンスターまたは「サキュバス」モンスターを戦闘で破壊し墓地へ送った時に発動する。カードを２枚ドローする。,[1]. This card deals double combat damage to demon type monsters and "Succubus" cards.\n[2]. When a demon type monster or "Succubus" card is destroyed in battle by this card and sent to the graveyard; draw 2 cards.
+[1].このカードが悪魔タイプのモンスターまたは「サキュバス」モンスターへ与える戦闘ダメージは倍になる。\n[2].悪魔タイプのモンスターまたは「サキュバス」モンスターを戦闘で破壊し墓地へ送った時に発動する。カードを２枚ドローする。,[1]. This card deals double combat damage to Demon and "Succubus" Type monsters.\n[2]. When this card destroys a Demon or "Succubus" Type monster by battle: Draw 2 cards.  
+

--- a/CSV/Language/English/Card/13.txt
+++ b/CSV/Language/English/Card/13.txt
@@ -1,3 +1,3 @@
 default
 宝石鉱夫,Gem Miner
-通常召喚に成功したときデッキからランダムに「ジェム」カードを2枚手札に加える。,On normal summon; add 2 random [Gem] cards to your hand.
+通常召喚に成功したときデッキからランダムに「ジェム」カードを2枚手札に加える。,When this card is Normal Summoned: Add 2 random [Gem] cards from your deck to your hand.

--- a/CSV/Language/English/Card/14.txt
+++ b/CSV/Language/English/Card/14.txt
@@ -1,3 +1,3 @@
 default
 竪琴の癒し手,Harp Healer
-このカードが召喚・特殊召喚に成功したとき発動する。自分フィールド上のモンスター全員のHPを500ポイント回復させる。,On normal or special summon; restore 500 HP to all monsters on your side of the field.
+このカードが召喚・特殊召喚に成功したとき発動する。自分フィールド上のモンスター全員のHPを500ポイント回復させる。,When this card is Summoned: Restore 500 HP to every monster on your field.

--- a/CSV/Language/English/Card/40001.txt
+++ b/CSV/Language/English/Card/40001.txt
@@ -1,3 +1,3 @@
 default
 パワーライズ,Power Rise
-フィールド上のモンスター１体の攻撃力を300ポイントアップさせる。,Increase target monster's attack by 300 points.
+フィールド上のモンスター１体の攻撃力を300ポイントアップさせる。,Target a monster; That monster gains 300 ATK.

--- a/CSV/Language/English/Card/40004.txt
+++ b/CSV/Language/English/Card/40004.txt
@@ -1,3 +1,3 @@
 default
 生命保証,Life Insurance
-場のモンスター１体を選択して発動する。そのモンスターに「このカードが戦闘で破壊されたとき、そのターンの終了時にカードを２枚ドローする」という効果を付与する。,Choose a monster. That monster gains the effect "If this card is destroyed in combat; draw 2 cards at the end of your turn."
+場のモンスター１体を選択して発動する。そのモンスターに「このカードが戦闘で破壊されたとき、そのターンの終了時にカードを２枚ドローする」という効果を付与する。,Target a monster; That monster gains "If this card is destroyed in combat: Draw 2 cards at the end of your turn."

--- a/CSV/Language/English/Card/40005.txt
+++ b/CSV/Language/English/Card/40005.txt
@@ -1,3 +1,3 @@
 default
 回復ポーション,Recovery Potion
-[1]モンスター１体を選択して発動する。そのHPを1500回復する。,[1]. Select one monster: That monster recovers 1500 HP.
+[1]モンスター１体を選択して発動する。そのHPを1500回復する。,[1]. Target a monster; That monster recovers 1500 HP.

--- a/CSV/Language/English/Card/40006.txt
+++ b/CSV/Language/English/Card/40006.txt
@@ -1,3 +1,3 @@
 default
 HP増強ポーション,Strong HP Potion
-フィールド上のモンスター１体の最大HPを1000ポイントアップさせる。,Select one monster on the field: Increase that monster's maximum HP by 1000 points.
+フィールド上のモンスター１体の最大HPを1000ポイントアップさせる。,Target a monster; That monsters gains 1000 MAX HP.

--- a/CSV/Language/English/Card/40007.txt
+++ b/CSV/Language/English/Card/40007.txt
@@ -1,3 +1,3 @@
 default
 守護の盾,Protection Shield
-場のモンスター１体に「次受ける戦闘ダメージは０になる」を付与する。,Grants one monster on the field "All Combat Damage Recieved next fight becomes 0".
+場のモンスター１体に「次受ける戦闘ダメージは０になる」を付与する。,Target a monster; That monster gains "All Combat Damage received next fight becomes 0".

--- a/CSV/Language/English/Card/40008.txt
+++ b/CSV/Language/English/Card/40008.txt
@@ -1,3 +1,3 @@
 default
 きあいだめ,Inner Strength
-[1].プレイヤーの攻撃力を100ポイント増加させる。このターンの終了時、自分フィールド上にモンスターがいなければ、カードを１枚ドローする。,[1]. Increases the player's ATK by 100 points.\n[2]. If there are no other monsters on your side of the field at the end of your turn; draw a card.
+[1].プレイヤーの攻撃力を100ポイント増加させる。このターンの終了時、自分フィールド上にモンスターがいなければ、カードを１枚ドローする。,[1]. Player gains 100 ATK.\n[2]. If you control no monsters at the end of the turn: Draw 1 card.

--- a/CSV/Language/English/Card/40009.txt
+++ b/CSV/Language/English/Card/40009.txt
@@ -1,3 +1,4 @@
 default
 ライフアップ,Life Up
-プレイヤーの最大HPを500ポイント増加させる。このターンの終了時、自分フィールド上にモンスターがいなければ、カードを１枚ドローする。,Increase player Max HP by 500 points. On the end of this turn; draw 1 card if there are no monsters on your field.
+プレイヤーの最大HPを500ポイント増加させる。このターンの終了時、自分フィールド上にモンスターがいなければ、カードを１枚ドローする。,Player gains 500 MAX HP.\nIf you control no monsters at the end of the turn: Draw 1 card.
+

--- a/CSV/Language/English/Card/40011.txt
+++ b/CSV/Language/English/Card/40011.txt
@@ -1,3 +1,3 @@
 default
 ライトニング,Lightning
-相手フィールド上のすべてのモンスターに500ポイントのダメージを与える。,Deals 500 points of damage to all monsters on your opponent's side of the field.
+相手フィールド上のすべてのモンスターに500ポイントのダメージを与える。,Deal 500 damage to all enemy monsters.

--- a/CSV/Language/English/Card/40015.txt
+++ b/CSV/Language/English/Card/40015.txt
@@ -1,3 +1,3 @@
 default
 ウインドカッター,Wind Cutter
-場のモンスター1体を選択して発動する。そのモンスターに200ポイントダメージを与える。もしも自分フィールド上にこのカード以外の風属性のカードがあるなら、その数×300ポイントダメージがアップする。,Deals 200 damage to a monster. This damage is increased by 300 for every other Wind card on your field.
+場のモンスター1体を選択して発動する。そのモンスターに200ポイントダメージを与える。もしも自分フィールド上にこのカード以外の風属性のカードがあるなら、その数×300ポイントダメージがアップする。,Target a monster; Deal 200 + 300 x X damage to that monster (X = number of other Wind card on your field).

--- a/CSV/Language/English/Card/40017.txt
+++ b/CSV/Language/English/Card/40017.txt
@@ -1,3 +1,3 @@
 default
 癒しの樹,Healing Tree
-[1].自分のターン終了時に発動する。自分フィールド上のすべてのモンスターのHPを400回復させる。,[1]. On the end of your turn; all of your monsters on the field recover 400 HP.
+[1].自分のターン終了時に発動する。自分フィールド上のすべてのモンスターのHPを400回復させる。,[1]. At the end of your turn: All monsters on your field recover 400 HP.

--- a/CSV/Language/English/Card/40018.txt
+++ b/CSV/Language/English/Card/40018.txt
@@ -1,3 +1,3 @@
 default
 武装放棄,Abandon Weapons
-LP500支払って発動する。フィールド上の表側表示の装備カードをすべて破壊する。,Pay 500LP to destroy all face-up Equipment cards on the field.
+LP500支払って発動する。フィールド上の表側表示の装備カードをすべて破壊する。,Pay 500LP; Destroy all face-up Equipment cards on the field.

--- a/CSV/Language/English/Card/40020.txt
+++ b/CSV/Language/English/Card/40020.txt
@@ -1,3 +1,4 @@
 default
 力のジェムLv1,Power Gem Lv1
-[1].キャラクター１体を選択して発動する。そのキャラクターの攻撃力を200ポイントアップさせる。,[1]. Increases ATK of target character by 200.
+[1].キャラクター１体を選択して発動する。そのキャラクターの攻撃力を200ポイントアップさせる。,[1]. Target a character ; That character gains 200 ATK.
+

--- a/CSV/Language/English/Card/40021.txt
+++ b/CSV/Language/English/Card/40021.txt
@@ -1,3 +1,4 @@
 default
 守りのジェムLv1,Defense Gem Lv1
-[1].キャラクター１体を選択して発動する。そのキャラクターの最大HPを200ポイントアップさせる。,[1]. Increases MAX HP of target character by 200.
+[1].キャラクター１体を選択して発動する。そのキャラクターの最大HPを200ポイントアップさせる。,[1]. Target a character ; That character gains 200 MAX HP.
+

--- a/CSV/Language/English/Card/40022.txt
+++ b/CSV/Language/English/Card/40022.txt
@@ -1,3 +1,3 @@
 default
 毒のジェムLv1,Poison Gem Lv1
-[1].フィールド上のモンスター１体を対象にして発動する。そのモンスターに毒200を与える。,[1]. Inflicts Poison(200) on target monster.
+[1].フィールド上のモンスター１体を対象にして発動する。そのモンスターに毒200を与える。,[1]. Target a monster; That monster gains [Poison(200)].

--- a/CSV/Language/English/Card/40023.txt
+++ b/CSV/Language/English/Card/40023.txt
@@ -1,3 +1,3 @@
 default
 ブラッディスラッシュ,Bloody Slash
-[1].自分フィールド上に戦士タイプモンスターがいる場合に、相手フィールド上のモンスター１体を選択して発動する。そのモンスターに1500ダメージを与える。,[1]Deals 1500 damage to an enemy monster. Requires a Warrior monster on your field.
+[1].自分フィールド上に戦士タイプモンスターがいる場合に、相手フィールド上のモンスター１体を選択して発動する。そのモンスターに1500ダメージを与える。,[1]If you have a Warrior Type monster on your field: Target an enemy monster; Deal 1500 damage to that monster.

--- a/CSV/Language/English/Card/5.txt
+++ b/CSV/Language/English/Card/5.txt
@@ -1,3 +1,3 @@
 default
 ロイヤルナイト,Royal Knight
-このカードが通常召喚に成功したとき、デッキからランダムにレベル４以下のモンスター1枚を手札に加える。,When this card is normal summoned; add a random level 4 or lower monster card from your deck to your hand.
+このカードが通常召喚に成功したとき、デッキからランダムにレベル４以下のモンスター1枚を手札に加える。,When this card is Normal Summoned: Add a random level 4 or lower monster from your deck to your hand.

--- a/CSV/Language/English/Card/50003.txt
+++ b/CSV/Language/English/Card/50003.txt
@@ -1,3 +1,3 @@
 default
 武器砕き,Weapon Break
-相手が装備カードを発動したときに発動できる。その装備カードの効果を無効にし破壊する。その後、自分はカードを１枚ドローする。,[1]. If an opponent activates an Equipment Card; negate that card's effect and destroy it. Then; draw 1 card.
+相手が装備カードを発動したときに発動できる。その装備カードの効果を無効にし破壊する。その後、自分はカードを１枚ドローする。,[1]. If your opponent activates an Equipment Card: Negate that card's effect and destroy it¡ then draw 1 card.

--- a/CSV/Language/English/Card/50004.txt
+++ b/CSV/Language/English/Card/50004.txt
@@ -1,3 +1,3 @@
 default
 トラバサミ,Steel Trap
-相手モンスターの通常召喚成功時に発動できる。そのモンスターに1000ポイントのダメージを与え、ターン終了時まで攻撃不能にする。,Activates on an opponent's normal summon. The summoned monster takes 1000 points of damage and cannot attack this turn.
+相手モンスターの通常召喚成功時に発動できる。そのモンスターに1000ポイントのダメージを与え、ターン終了時まで攻撃不能にする。,If your opponent Normal Summons a monster: Deal 1000 damage to that monster and it cannot attack this turn.

--- a/CSV/Language/English/Card/50007.txt
+++ b/CSV/Language/English/Card/50007.txt
@@ -1,3 +1,3 @@
 default
 ダブルスラッシュ,Double Slash
-[1].自分のローグタイプのモンスターが攻撃宣言をしたときに発動できる。次の戦闘で、そのモンスターの攻撃回数を+1する。,[1]. Can be activated when a rogue type monster you control declares an attack. During the next fight; the number of times that monster can attack is increased by 1.
+[1].自分のローグタイプのモンスターが攻撃宣言をしたときに発動できる。次の戦闘で、そのモンスターの攻撃回数を+1する。,[1]. If a Rogue Type monster you control declares an attack: During this fight its attack hit one more time.

--- a/CSV/Language/English/Card/50009.txt
+++ b/CSV/Language/English/Card/50009.txt
@@ -1,3 +1,3 @@
 default
 防壁突破,Barricade Breakthrough
-[1].自分キャラクターの攻撃宣言時に相手が罠カードを使用した場合、手札を1枚捨てて発動できる。そのトラップカードの効果を無効にし破壊する。,[1]. If an opponent uses a Trap card during the attack declaration of your character; you may discard 1 card from your hand to negate and destroy that Trap card.
+[1].自分キャラクターの攻撃宣言時に相手が罠カードを使用した場合、手札を1枚捨てて発動できる。そのトラップカードの効果を無効にし破壊する。,[1]. If your opponent activates a Trap Card when your character declares an attack: Discard 1 card; Negate the Trap Card's effect and destroy it.

--- a/CSV/Language/English/Card/50022.txt
+++ b/CSV/Language/English/Card/50022.txt
@@ -1,3 +1,3 @@
 default
 盗賊の印,Thief's calling card
-[1].フィールド上のモンスターが戦闘で破壊されたときに発動できる。デッキからローグタイプのモンスターをランダムに1枚手札に加える。,[1]. If a monster on the field is destroyed in battle: Add 1 random Rogue-type monster from the Deck into your hand.
+[1].フィールド上のモンスターが戦闘で破壊されたときに発動できる。デッキからローグタイプのモンスターをランダムに1枚手札に加える。,[1]. If a monster is destroyed by battle: Add 1 random Rogue Type monster from your Deck to your hand.

--- a/CSV/Language/English/Card/6.txt
+++ b/CSV/Language/English/Card/6.txt
@@ -1,3 +1,3 @@
 default
 ハイバンディット,High Bandit
-このカードが攻撃宣言を行うたびに、LPを800払って発動する。このカードの攻撃力を500ポイントアップする。,When this card attacks; pay 800LP to increase its attack by 500.
+このカードが攻撃宣言を行うたびに、LPを800払って発動する。このカードの攻撃力を500ポイントアップする。,When this card declares an attack: Pay 800LP; This card gains 500 ATK.

--- a/CSV/Language/English/Card/60001.txt
+++ b/CSV/Language/English/Card/60001.txt
@@ -1,3 +1,3 @@
 default
 風のカタナ,Wind Katana
-戦士タイプモンスターに装備可能。\n[1].攻撃力400ポイントアップ。装備モンスターの属性はこのカードを装備している間、風属性になる。,Equippable to Warriors. \n[1]. Increases ATK by 400. Equipped monsters' attribute changes to Wind while holding this equipment.
+戦士タイプモンスターに装備可能。\n[1].攻撃力400ポイントアップ。装備モンスターの属性はこのカードを装備している間、風属性になる。,Can only be equipped to Warrior Type monsters. \n[1]. The equipped monster gains 400 ATK and it becomes Wind Attribute.

--- a/CSV/Language/English/Card/60003.txt
+++ b/CSV/Language/English/Card/60003.txt
@@ -1,3 +1,3 @@
 default
 ポイズンクロー,Poison Claw
-ローグタイプのみ装備可能。\n[1].攻撃力を200ポイントアップ。戦闘時に相手に「毒」(300)を与える。,Equippable by Rogues.\n[1].Increases ATK by 100. Inflicts [Poison](300) to the enemy in combat.
+ローグタイプのみ装備可能。\n[1].攻撃力を200ポイントアップ。戦闘時に相手に「毒」(300)を与える。,Can only be equipped to Rogue Type monsters.\n[1].The equipped monster gains 100 ATK and monsters it fights gain [Poison(300)].

--- a/CSV/Language/English/Card/60004.txt
+++ b/CSV/Language/English/Card/60004.txt
@@ -1,3 +1,3 @@
 default
 アイアンリング,Iron Ring
-フィールド上のモンスターまたはプレイヤーが装備可能。相手から受ける戦闘ダメージを100ポイント減少させる。,Equippable to any monster or player. Reduces combat damage taken by 100.
+フィールド上のモンスターまたはプレイヤーが装備可能。相手から受ける戦闘ダメージを100ポイント減少させる。,Can be equipped to anybody.\nReduces the combat damage taken by the equipped character by 100.

--- a/CSV/Language/English/Card/7.txt
+++ b/CSV/Language/English/Card/7.txt
@@ -1,3 +1,3 @@
 default
 ナイフ使い,Knife Wielder
-戦闘でダメージを与えたとき相手に毒200を与える。,Whenever this monster deals combat damage; that enemy gains [Poison (200)].
+戦闘でダメージを与えたとき相手に毒200を与える。,When this monster deals combat damage to a character: That character gains [Poison (200)].


### PR DESCRIPTION
Unified the syntax for all the players cards found in the first booster pack. 

Not completely sure about some of the changes, but everything is taken from YGO here, so there is at least a popular precedent for it. 

The biggest issue is a semi-colon, I should replace it by something else, but I do not want it fuse it with the activation requirements (which already uses colons) since it makes it can make it too confusing for some cards. 

There are still some elements of syntax I haven't taken from YGO (It uses "you control/your opponent controls" instead of "On your field/enemy cards". Should I use that too? 