### PR TITLE
Player cards/second booster

### DIFF
--- a/CSV/Language/English/Card/14.txt
+++ b/CSV/Language/English/Card/14.txt
@@ -1,3 +1,3 @@
 default
 竪琴の癒し手,Harp Healer
-このカードが召喚・特殊召喚に成功したとき発動する。自分フィールド上のモンスター全員のHPを500ポイント回復させる。,When this card is Summoned: Restore 500 HP to every monster on your field.
+このカードが召喚・特殊召喚に成功したとき発動する。自分フィールド上のモンスター全員のHPを500ポイント回復させる。,When this card is Summoned: Restore 500 HP to every monster you control.

--- a/CSV/Language/English/Card/15.txt
+++ b/CSV/Language/English/Card/15.txt
@@ -1,3 +1,3 @@
 default
 黒猫魔術師,Black Cat Magician
-1ターンに１度800LP払って発動できる。デッキからランダムに魔法カードを１枚手札に加える（デッキに魔法カードが1枚もないときには発動できない）。,Pay 800LP (once per turn): Add one random Spell Card from the deck to your hand (cannot be used if there are no Spell Cards in the deck).
+1ターンに１度800LP払って発動できる。デッキからランダムに魔法カードを１枚手札に加える（デッキに魔法カードが1枚もないときには発動できない）。,Once per turn: You can pay 800LP; Add 1 random Spell Card from your deck to your hand.

--- a/CSV/Language/English/Card/16.txt
+++ b/CSV/Language/English/Card/16.txt
@@ -1,3 +1,3 @@
 default
 神弓の使い手,Divine Bow Wielder
-このカードが通常召喚に成功したときに発動する。自分の墓地のハンタータイプのモンスターの数×400ポイントダメージを相手フィールド上のすべてのモンスターに与える。,[1]. When this card is Normal Summoned: Deal 400 x X points of damage to all monsters on the opponent's field (X = the number of Hunter Type monsters in your Graveyard).
+このカードが通常召喚に成功したときに発動する。自分の墓地のハンタータイプのモンスターの数×400ポイントダメージを相手フィールド上のすべてのモンスターに与える。,[1]. When this card is Normal Summoned: Deal 400 x X damage to all monsters your opponent controls (X = Number of Hunter Type monsters in your Graveyard).

--- a/CSV/Language/English/Card/17.txt
+++ b/CSV/Language/English/Card/17.txt
@@ -1,3 +1,3 @@
 default
 ポセイドンナイト,Poseidon Knight
-[1].水属性の魔法・トラップカードが発動した時発動する。このカードの攻撃力と最大HPを100ポイントアップする。,[1]. After activating a water attribute spell or trap card; increase this monster's Atk and Max HP by 100.
+[1].水属性の魔法・トラップカードが発動した時発動する。このカードの攻撃力と最大HPを100ポイントアップする。,[1]. When a Water Attribute Spell/Trap Card is activated: This card gains 100 ATK and MAX HP.

--- a/CSV/Language/English/Card/18.txt
+++ b/CSV/Language/English/Card/18.txt
@@ -1,4 +1,4 @@
 default
 偵察者,Scout
-このカードが場に出たとき、相手フィールド上の魔法・トラップカードを1枚選択して発動できる。そのカードを相手の手札に戻す。,When this card is normal summoned; you may return one spell or trap card from the opponent's side of the field to their hand.
+このカードが場に出たとき、相手フィールド上の魔法・トラップカードを1枚選択して発動できる。そのカードを相手の手札に戻す。,When this card is Normal Summoned: You can return 1 Spell/Trap Card your opponent controls to their hand.
 羊飼いのふりをして他国の情勢を探る偵察者。眼光鋭いその目は、どんな変化も見逃さない。,羊飼いのふりをして他国の情勢を探る偵察者。眼光鋭いその目は、どんな変化も見逃さない。

--- a/CSV/Language/English/Card/19.txt
+++ b/CSV/Language/English/Card/19.txt
@@ -1,3 +1,3 @@
 default
 ビーストシャーマン,Beast Shaman
-このカードが通常召喚に成功したとき、自分フィールド上のモンスター1体を選択して発動できる。そのモンスターに成長（自分のターン終了ごとに、HPを200ポイントアップ）を付与する。,Upon successfully being normal summoned; select one monster on your side of the field. That monster gains [Growth] (Max HP is increased by 200 at the end of your turn).
+このカードが通常召喚に成功したとき、自分フィールド上のモンスター1体を選択して発動できる。そのモンスターに成長（自分のターン終了ごとに、HPを200ポイントアップ）を付与する。,When this card is Normal Summoned: Target 1 monster you control; That monster gains [Growth] (This monster gains 200 MAX HP at the end of your turn).

--- a/CSV/Language/English/Card/20.txt
+++ b/CSV/Language/English/Card/20.txt
@@ -1,3 +1,3 @@
 default
 スマッシュドワーフ,Smash Dwarf
-[1].自分が「ジェム」カードを発動するたびにこのカードの攻撃力は200ポイントアップする。\n[2].このカードが戦闘で破壊され墓地へ送られたとき、デッキから「ジェム」カードを1枚ランダムに手札に加える。,[1]. Increase this card's attack power by 200 points for every "Gem" card you activate. \n[2]. When this card is destroyed in combat and sent to the graveyard; add one random "Gem" card from the deck into your hand.
+[1].自分が「ジェム」カードを発動するたびにこのカードの攻撃力は200ポイントアップする。\n[2].このカードが戦闘で破壊され墓地へ送られたとき、デッキから「ジェム」カードを1枚ランダムに手札に加える。,[1]. When you activate a "Gem" Card: This card gains 200 ATK. \n[2]. When this card is destroyed by battle and sent to the Graveyard: Add 1 random "Gem" Card from your deck to your hand.

--- a/CSV/Language/English/Card/21.txt
+++ b/CSV/Language/English/Card/21.txt
@@ -1,3 +1,3 @@
 default
 羽の騎士,Feather Knight
-1ターンに1度LPを1000払って発動できる。このターンの間、このカードは相手プレイヤーに直接攻撃できる。,Once per turn; you may pay 1000 LP. Until end of turn; this monster may directly attack your opponent.
+1ターンに1度LPを1000払って発動できる。このターンの間、このカードは相手プレイヤーに直接攻撃できる。,Once per turn: You can pay 1000 LP; This card can attack your opponent directly until the end of the turn.

--- a/CSV/Language/English/Card/22.txt
+++ b/CSV/Language/English/Card/22.txt
@@ -1,3 +1,3 @@
 default
 大ナタぶるい,Giant Machete Wielder
-1ターンに1度手札を2枚捨てて発動できる。相手フィールド上のすべてのモンスターにこのモンスターの攻撃力分のダメージを与える。,Once per turn; you may discard 2 cards from hand. Upon doing so; deal damage equal to this monster's ATK to all monsters on the enemy's side of the field.
+1ターンに1度手札を2枚捨てて発動できる。相手フィールド上のすべてのモンスターにこのモンスターの攻撃力分のダメージを与える。,Once per turn: You can discard 2 cards from your hand; Deal damage to all monsters your opponent controls equal to this card's ATK.

--- a/CSV/Language/English/Card/23.txt
+++ b/CSV/Language/English/Card/23.txt
@@ -1,3 +1,3 @@
 default
 エルダーシャーマン,Elder Shaman
-1ターンに1度、フィールド上のモンスター１体を選択して発動できる。そのモンスターのHPを300ポイントアップさせる。,Once per turn; you may select 1 monster on your side of the field. That monster gains 300 Max HP.
+1ターンに1度、フィールド上のモンスター１体を選択して発動できる。そのモンスターのHPを300ポイントアップさせる。,Once per turn: You can target 1 monster you control; That monster gains 300 MAX HP.

--- a/CSV/Language/English/Card/25.txt
+++ b/CSV/Language/English/Card/25.txt
@@ -1,3 +1,3 @@
 default
 霊鳥使いキュベル,Spirit Bird Tamer Cubel
-[1].自分が風属性のモンスターを場に出したとき、または風属性の魔法・トラップカードの効果を発動したときに発動する。ランダムな相手モンスターに300ポイントダメージを与える。,[1]. When a Wind Attribute Monster enters your side of the field or you activate a Wind Spell Card/Trap Card; Deal 300 damage to a random enemy monster.
+[1].自分が風属性のモンスターを場に出したとき、または風属性の魔法・トラップカードの効果を発動したときに発動する。ランダムな相手モンスターに300ポイントダメージを与える。,[1]. When you Summon a Wind Attribute monster or you activate a Wind Attribute Spell/Trap Card: Deal 300 damage to a random monster your opponent controls.

--- a/CSV/Language/English/Card/26.txt
+++ b/CSV/Language/English/Card/26.txt
@@ -1,3 +1,3 @@
 default
 風呼び召喚師,Lightning
-[1].このカードが通常召喚に成功したとき、手札を1枚捨てて発動できる。デッキから風属性のレベル4以下のモンスター1体をランダムに特殊召喚する（デッキ内に該当するカードが存在しない場合発動しない）。,[1]. Upon this card being normal summoned; you may discard 1 card from hand. If you do so; special summon 1 random Wind Attribute monster of Level 4 or lower onto the field. (Will not activate if no cards in your deck fit those parameters.)
+[1].このカードが通常召喚に成功したとき、手札を1枚捨てて発動できる。デッキから風属性のレベル4以下のモンスター1体をランダムに特殊召喚する（デッキ内に該当するカードが存在しない場合発動しない）。,[1]. When this card is Normal Summoned: You can discard 1 card from your hand; Special Summon 1 random level 4 or lower Wind Attribute monster from your Deck.

--- a/CSV/Language/English/Card/28.txt
+++ b/CSV/Language/English/Card/28.txt
@@ -1,3 +1,3 @@
 default
 ブラックスミス,Blacksmith
-[1].1ターンに1度、このカード以外のモンスター1体を選択して発動できる。そのモンスターの攻撃力を300ポイントアップさせる。,[1]. Once per turn; select 1 monster on the field other than this one. Increase that monster's Atk by 300.
+[1].1ターンに1度、このカード以外のモンスター1体を選択して発動できる。そのモンスターの攻撃力を300ポイントアップさせる。,[1]. Once per turn: You can target another monster; That monster gains 300 ATK.

--- a/CSV/Language/English/Card/29.txt
+++ b/CSV/Language/English/Card/29.txt
@@ -1,3 +1,3 @@
 default
 熟練の暗殺者,Skilled Assassin
-1ターンに1度、フィールド上モンスター1体を選択し、LPを500払って発動できる。そのモンスターに毒600を付与する。,Once per turn; you may pay 500 LP to pick one monster on the field and inflict 600 poison to it.
+1ターンに1度、フィールド上モンスター1体を選択し、LPを500払って発動できる。そのモンスターに毒600を付与する。,Once per turn: You can pay 500LP and target 1 monster; That monster gains [Poison(600)]

--- a/CSV/Language/English/Card/40008.txt
+++ b/CSV/Language/English/Card/40008.txt
@@ -1,3 +1,3 @@
 default
 きあいだめ,Inner Strength
-[1].プレイヤーの攻撃力を100ポイント増加させる。このターンの終了時、自分フィールド上にモンスターがいなければ、カードを１枚ドローする。,[1]. Player gains 100 ATK.\n[2]. If you control no monsters at the end of the turn: Draw 1 card.
+[1].プレイヤーの攻撃力を100ポイント増加させる。このターンの終了時、自分フィールド上にモンスターがいなければ、カードを１枚ドローする。,[1]. You gain 100 ATK.\n[2]. If you control no monsters at the end of the turn: Draw 1 card.

--- a/CSV/Language/English/Card/40009.txt
+++ b/CSV/Language/English/Card/40009.txt
@@ -1,4 +1,4 @@
 default
 ライフアップ,Life Up
-プレイヤーの最大HPを500ポイント増加させる。このターンの終了時、自分フィールド上にモンスターがいなければ、カードを１枚ドローする。,Player gains 500 MAX HP.\nIf you control no monsters at the end of the turn: Draw 1 card.
+プレイヤーの最大HPを500ポイント増加させる。このターンの終了時、自分フィールド上にモンスターがいなければ、カードを１枚ドローする。,You gain 500 MAX HP.\nIf you control no monsters at the end of the turn: Draw 1 card.
 

--- a/CSV/Language/English/Card/40011.txt
+++ b/CSV/Language/English/Card/40011.txt
@@ -1,3 +1,3 @@
 default
 ライトニング,Lightning
-相手フィールド上のすべてのモンスターに500ポイントのダメージを与える。,Deal 500 damage to all enemy monsters.
+相手フィールド上のすべてのモンスターに500ポイントのダメージを与える。,Deal 500 damage to all monsters your opponent controls.

--- a/CSV/Language/English/Card/40017.txt
+++ b/CSV/Language/English/Card/40017.txt
@@ -1,3 +1,3 @@
 default
 癒しの樹,Healing Tree
-[1].自分のターン終了時に発動する。自分フィールド上のすべてのモンスターのHPを400回復させる。,[1]. At the end of your turn: All monsters on your field recover 400 HP.
+[1].自分のターン終了時に発動する。自分フィールド上のすべてのモンスターのHPを400回復させる。,[1]. At the end of your turn: All monsters you control recover 400 HP.

--- a/CSV/Language/English/Card/40019.txt
+++ b/CSV/Language/English/Card/40019.txt
@@ -1,3 +1,3 @@
 default
 水の守り,Water Barrier
-次の自分ターン開始時まで、このカードを使用したプレイヤーが受ける戦闘ダメージは半分になる。,Halves combat damage taken by the player until their next turn.
+次の自分ターン開始時まで、このカードを使用したプレイヤーが受ける戦闘ダメージは半分になる。,Halve the combat damage you take until your next turn.

--- a/CSV/Language/English/Card/40023.txt
+++ b/CSV/Language/English/Card/40023.txt
@@ -1,3 +1,3 @@
 default
 ブラッディスラッシュ,Bloody Slash
-[1].自分フィールド上に戦士タイプモンスターがいる場合に、相手フィールド上のモンスター１体を選択して発動する。そのモンスターに1500ダメージを与える。,[1]If you have a Warrior Type monster on your field: Target an enemy monster; Deal 1500 damage to that monster.
+[1].自分フィールド上に戦士タイプモンスターがいる場合に、相手フィールド上のモンスター１体を選択して発動する。そのモンスターに1500ダメージを与える。,[1]If you have a Warrior Type monster on your field: Target a monster you opponent controls; Deal 1500 damage to that monster.

--- a/CSV/Language/English/Card/40025.txt
+++ b/CSV/Language/English/Card/40025.txt
@@ -1,3 +1,3 @@
 default
 バブルチェイン,Bubble Chain
-[1].ライフを500払い、自分フィールド上にいる水属性モンスター1体を選択して発動する。そのモンスターと同じレベルの水属性モンスターを、ランダムにデッキから1枚手札に加える。,[1]. Pay 500 Life: Choose a water monster on your side of the field. Add one random Water Attribute to your hand equal to that monster's level.
+[1].ライフを500払い、自分フィールド上にいる水属性モンスター1体を選択して発動する。そのモンスターと同じレベルの水属性モンスターを、ランダムにデッキから1枚手札に加える。,[1]. Pay 500 Life and target a Water Attribute monster you control; Add 1 random Water Attribute monster from your deck to your hand whose level is equal to that monster's level.

--- a/CSV/Language/English/Card/40026.txt
+++ b/CSV/Language/English/Card/40026.txt
@@ -1,3 +1,4 @@
 default
 エンハンスドロー,Enhanced Draw
-[1].次の自分ターン開始時に自分の場にモンスターが1体もいないならば、通常のドローに加えさらにカードを2枚ドローする。このカードは自分の手札が5枚以下のときにのみ発動できる。,[1]. If there are no monsters on your field at the beginning of your next turn; draw 2 more additional cards. (This card can only be activated when you have 5 or fewer cards in your hand.)
+[1].次の自分ターン開始時に自分の場にモンスターが1体もいないならば、通常のドローに加えさらにカードを2枚ドローする。このカードは自分の手札が5枚以下のときにのみ発動できる。,[1]. If there are no monsters on your field at the beginning of your next turn: Draw 2 cards. (This card can only be activated when you have 5 or less cards in your hand.)
+

--- a/CSV/Language/English/Card/40027.txt
+++ b/CSV/Language/English/Card/40027.txt
@@ -1,3 +1,3 @@
 default
 ライフチェンジ,Life Change
-[1].フィールド上のモンスター2体を選択して発動する。そのモンスターのHPを互いに入れ替える（最大HPも交換される）。,[1]. Select 2 monsters on the field. Swap the HP values of those two monsters (including maximum HP).
+[1].フィールド上のモンスター2体を選択して発動する。そのモンスターのHPを互いに入れ替える（最大HPも交換される）。,[1]. Target 2 monsters; Swap the HP and MAX HP of these two monsters.

--- a/CSV/Language/English/Card/40028.txt
+++ b/CSV/Language/English/Card/40028.txt
@@ -1,3 +1,3 @@
 default
 フレイム,Flame
-[1].400LPを払い、フィールド上のモンスター１体を選択して発動する。そのモンスターに900ポイントダメージを与える。,[1]. Pay 400LP and select one monster on the field. That monster takes 900 damage.
+[1].400LPを払い、フィールド上のモンスター１体を選択して発動する。そのモンスターに900ポイントダメージを与える。,[1]. Pay 400LP and target 1 monster; Deal 900 damage to that monster.

--- a/CSV/Language/English/Card/40029.txt
+++ b/CSV/Language/English/Card/40029.txt
@@ -1,3 +1,3 @@
 default
 パワーストライク,Power Strike
-自分のフィールド上および墓地にモンスターが1枚も存在しない場合に発動できる。相手フィールド上のモンスター1体に、プレイヤーの攻撃力分のダメージを与える。,If there are no monsters on your field or Graveyard; you may deal damage to a monster on the opponent's field equal to the player's attack value.
+自分のフィールド上および墓地にモンスターが1枚も存在しない場合に発動できる。相手フィールド上のモンスター1体に、プレイヤーの攻撃力分のダメージを与える。,If there are no monsters on your field or Graveyard: Target 1 monster; Deal damage to that monster equal to your ATK.

--- a/CSV/Language/English/Card/40030.txt
+++ b/CSV/Language/English/Card/40030.txt
@@ -1,3 +1,3 @@
 default
 けむりだま,Smoke Bomb
-自分フィールド上のモンスター1体を選択し発動する。そのカードを手札に戻す。,Choose a monster on your side of the field. Return that card to your hand.
+自分フィールド上のモンスター1体を選択し発動する。そのカードを手札に戻す。,Target a monster you control; Return that monster to your hand.

--- a/CSV/Language/English/Card/40032.txt
+++ b/CSV/Language/English/Card/40032.txt
@@ -1,3 +1,3 @@
 default
 フレイムウィップ,Flame Whip
-[1].手札からカードを1枚捨てて発動する。相手フィールド上のすべてのモンスターに1000ポイントダメージを与える。,[1]. Discard a card from your hand and deal 1000 points of damage to all monsters on your opponent's side of the field.
+[1].手札からカードを1枚捨てて発動する。相手フィールド上のすべてのモンスターに1000ポイントダメージを与える。,[1]. Discard 1 card from your hand; Deal 1000 damage to all monsters your opponent controls.

--- a/CSV/Language/English/Card/40033.txt
+++ b/CSV/Language/English/Card/40033.txt
@@ -1,3 +1,3 @@
 default
 武器の鍛錬,Arms Forge
-[1].フィールド上のキャラクター1体を選択して発動する。そのキャラクターの攻撃力をそのモンスターが装備しているカードの数×400ポイントアップする。,[1]. Select a character on the field. Increase that character's attack power by 400 x X (X = the number of cards equipped).
+[1].フィールド上のキャラクター1体を選択して発動する。そのキャラクターの攻撃力をそのモンスターが装備しているカードの数×400ポイントアップする。,[1]. Target a character; That character gains 400 x X ATK (X = Number of cards equipped to it).

--- a/CSV/Language/English/Card/40034.txt
+++ b/CSV/Language/English/Card/40034.txt
@@ -1,3 +1,3 @@
 default
 氷のつぶて,Ice Shard
-[2].フィールド上のモンスター1体を選択して発動する。そのモンスターに300ポイントダメージを与え、「凍結」（次のターンまで攻撃宣言不能）を付与する。,[1]. Choose one monster on the field. That monster receives 300 points of damage and is inflicted with [Freeze] (monster cannot attack next turn).
+[1].フィールド上のモンスター1体を選択して発動する。そのモンスターに300ポイントダメージを与え、「凍結」（次のターンまで攻撃宣言不能）を付与する。,[1]. Target 1 monster; Deal 300 damage to that monster and it gains [Freeze] (This monster cannot declare an attack).

--- a/CSV/Language/English/Card/40035.txt
+++ b/CSV/Language/English/Card/40035.txt
@@ -1,3 +1,3 @@
 default
 幸運のクローバー,Lucky Clover
-クールタイム4\n[1].LPを400払って発動する。デッキからカードを1枚ドローする。そのカードがレベル４モンスターだった場合、さらにもう1枚カードをドローする。,Cooldown 4\n[1]. Pay 400 LP and draw a card from the deck; if that card is a level 4 monster; draw another card.
+クールタイム4\n[1].LPを400払って発動する。デッキからカードを1枚ドローする。そのカードがレベル４モンスターだった場合、さらにもう1枚カードをドローする。,Cooldown 4\n[1]. Pay 400 LP; Draw 1 card. If that card is a level 4 monster; draw another card.

--- a/CSV/Language/English/Card/40036.txt
+++ b/CSV/Language/English/Card/40036.txt
@@ -1,3 +1,3 @@
 default
 聖なるともしび,Sacred Light
-LPを500払い発動する。\n[1].このカードがフィールド上にある限り、闇属性モンスターのHPは300ポイントダウン。光属性モンスターのHPは300ポイントアップ。,Pay 500 LP to activate.\n[1]. As long as this card is on the field; Dark Attribute monsters have their HP decreased by 300 points. Light Attribute monsters have their HP increased by 300 points.
+LPを500払い発動する。\n[1].このカードがフィールド上にある限り、闇属性モンスターのHPは300ポイントダウン。光属性モンスターのHPは300ポイントアップ。,Pay 500 LP to activate.\n[1]. While this card is on the field: Dark Attribute monsters lose 300 HP and Light Attribute monsters gain 300 HP.

--- a/CSV/Language/English/Card/40037.txt
+++ b/CSV/Language/English/Card/40037.txt
@@ -1,3 +1,3 @@
 default
 エレメントの調和,Attributeal Harmony
-[1].自分の墓地に火属性、水属性、地属性、風属性のカードがそれぞれ1枚以上あるとき発動できる。キャラクター1体のHPと攻撃力を1000ポイントアップする。,[1]. Activate when there is at least 1 of each Fire; Water; Earth; and Wind Attribute card in your Graveyard. Increase the HP and attack power of a character by 1000 points.
+[1].自分の墓地に火属性、水属性、地属性、風属性のカードがそれぞれ1枚以上あるとき発動できる。キャラクター1体のHPと攻撃力を1000ポイントアップする。,[1]. If there is at least 1 card of each of the following Attribute in your Graveyard (Fire, Water, Earth and Wind): Target 1 character; Target character gains 1000 ATK and MAX HP.

--- a/CSV/Language/English/Card/40039.txt
+++ b/CSV/Language/English/Card/40039.txt
@@ -1,3 +1,3 @@
 default
 弱体化,Weaken
-フィールド上のモンスター1体を選択して発動する。そのモンスターの攻撃力を半分にする。,Choose a monster on the field; that monster has its attack power cut in half.
+フィールド上のモンスター1体を選択して発動する。そのモンスターの攻撃力を半分にする。,Target 1 monster; That monster's ATK becomes half its current ATK.

--- a/CSV/Language/English/Card/40040.txt
+++ b/CSV/Language/English/Card/40040.txt
@@ -1,3 +1,3 @@
 default
 戦意高揚対戦,Fighting Spirit
-自分フィールド上のすべてのモンスターの攻撃力を２００ポイントアップさせる。,Increase the attack of all monsters on your side of the field by 200 points.
+自分フィールド上のすべてのモンスターの攻撃力を２００ポイントアップさせる。,All monsters you control gain 200 ATK.

--- a/CSV/Language/English/Card/40041.txt
+++ b/CSV/Language/English/Card/40041.txt
@@ -1,3 +1,4 @@
 default
 生命の果実,Fruit of Life
-自分フィールド上のモンスター1体に「成長」（自分ターン終了時ごとにHPを200ポイントアップ）を付与する。,Target monster on your side of the field gains "Growth" (HP increases by 200 points at the end of your turn.)
+自分フィールド上のモンスター1体に「成長」（自分ターン終了時ごとにHPを200ポイントアップ）を付与する。,Target 1 monster you control; That monster gains [Growth] (This monster gains 200 MAX HP at the end of your turn).
+

--- a/CSV/Language/English/Card/50005.txt
+++ b/CSV/Language/English/Card/50005.txt
@@ -1,3 +1,3 @@
 default
 返しの刃,Counter Blade
-[1].防御状態の自分のモンスターが相手から攻撃されたとき発動できる。そのモンスターの攻撃力をターン終了時まで1000ポイントアップさせ、防御状態を解除する。,[1]. When your monster in Defense Position is attacked; increase that monster's attack power by 1000 points and change it to Attack Position until the end of the turn.
+[1].防御状態の自分のモンスターが相手から攻撃されたとき発動できる。そのモンスターの攻撃力をターン終了時まで1000ポイントアップさせ、防御状態を解除する。,[1]. If a defense position monster you control is attacked: That monster is changed to attack position and it gains 1000 ATK until the end of the turn.

--- a/CSV/Language/English/Card/50014.txt
+++ b/CSV/Language/English/Card/50014.txt
@@ -1,3 +1,3 @@
 default
 ポイズンボトル,Poison Bottle
-モンスターが特殊召喚に成功したとき発動できる。相手フィールド上のすべてのモンスターに毒（500,[1]. When a monster is successfully Special Summoned; inflict [Poison (500)] to all monsters on your opponent's field.
+モンスターが特殊召喚に成功したとき発動できる。相手フィールド上のすべてのモンスターに毒（500,If a monster is Special Summoned: All monsters your opponent controls gain [Poison (500)] for 3 turns.

--- a/CSV/Language/English/Card/50015.txt
+++ b/CSV/Language/English/Card/50015.txt
@@ -1,3 +1,3 @@
 default
 鉱石発掘,Ore Excavation
-炎属性の魔法カードが発動されたとき発動できる。「力のジェムLv1」を3枚手札に加える。,[1]. If a Fire Attribute Spell Card is activated; add 3 "Power Gem Lv1" cards to your hand.
+炎属性の魔法カードが発動されたとき発動できる。「力のジェムLv1」を3枚手札に加える。,[1]. If a Fire Attribute Spell Card is activated: Generate and add 3 "Power Gem Lv1" to your hand.

--- a/CSV/Language/English/Card/50016.txt
+++ b/CSV/Language/English/Card/50016.txt
@@ -1,3 +1,3 @@
 default
 連鎖感電,Chain Electrocution
-光属性の魔法カードが発動されたときに発動できる。相手フィールド上のすべてのモンスターに600ポイントのダメージを与える。,[1]. When a Light Attribute Spell Card is activated; inflict 600 damage to all monsters on your opponent's field.
+光属性の魔法カードが発動されたときに発動できる。相手フィールド上のすべてのモンスターに600ポイントのダメージを与える。,[1]. If a Light Attribute Spell Card is activated: Deal 600 damage to all monsters you opponent controls.

--- a/CSV/Language/English/Card/50017.txt
+++ b/CSV/Language/English/Card/50017.txt
@@ -1,3 +1,3 @@
 default
 託された剣,Entrusted Sword
-[1].自分フィールド上の戦士タイプモンスターが戦闘によって破壊されたとき発動できる。デッキからランダムにレベル4以下の戦士タイプモンスター1体を特殊召喚する。,[1]. When a Warrior Type monster on your field is destroyed by battle; you may Special Summon 1 Level 4 or lower Warrior Type monster from your Deck at random.
+[1].自分フィールド上の戦士タイプモンスターが戦闘によって破壊されたとき発動できる。デッキからランダムにレベル4以下の戦士タイプモンスター1体を特殊召喚する。,[1]. If a Warrior Type monster you control is destroyed by battle: Special Summon 1 random level 4 or lower Warrior Type monster from your Deck.

--- a/CSV/Language/English/Card/50018.txt
+++ b/CSV/Language/English/Card/50018.txt
@@ -1,3 +1,3 @@
 default
 一刀両断,Decisive Slash
-[1].自分が戦士タイプモンスターの通常召喚に成功したとき手札を１枚捨てて発動できる。そのモンスターの攻撃力分のダメージをすべての相手モンスターに与える。この効果で相手モンスターを破壊した場合、召喚したモンスターの攻撃力を破壊した数*400ポイントアップする。,[1]. When you normal Summon a Warrior Type monster; you may discard 1 card from your hand to deal damage equal to the summoned monster's attack to all your opponent's monsters.\nIf you destroy an opponent's monster in this way; increase the attack of the summoned monster by X points (X = the number of monsters destroyed x 400).
+[1].自分が戦士タイプモンスターの通常召喚に成功したとき手札を１枚捨てて発動できる。そのモンスターの攻撃力分のダメージをすべての相手モンスターに与える。この効果で相手モンスターを破壊した場合、召喚したモンスターの攻撃力を破壊した数*400ポイントアップする。,[1]. If you Normal Summon a Warrior Type monster: Discard 1 card from your hand; Deal damage equal to the summoned monster's ATK to all monsters your opponent controls.\nThe summoned monster gains 400 x X ATK (X = Number of monsters destroyed by this effect).

--- a/CSV/Language/English/Card/50019.txt
+++ b/CSV/Language/English/Card/50019.txt
@@ -1,3 +1,3 @@
 default
 待ち伏せ,Ambush
-自分のハンタータイプのモンスターが相手の攻撃対象になったとき発動できる。攻撃してきた相手に1000ポイントのダメージを与える。,If a hunter type monster you control is attacked; the attacker receives 1000 points of damage.
+[1].自分のハンタータイプのキャラクターが相手の攻撃対象になったとき発動できる。攻撃してきた相手に1000ポイントのダメージを与える。,[1].If a Hunter Type character you control is attacked: Deal 1000 damage to the attacker.

--- a/CSV/Language/English/Card/50020.txt
+++ b/CSV/Language/English/Card/50020.txt
@@ -1,3 +1,3 @@
 default
 ブリザードブレス,Blizzard Breath
-[1].相手がモンスターを通常召喚・特殊召喚したとき発動できる。相手フィールド上のすべてのモンスターに500ポイントダメージを与え、「凍結」（２ターンの間、攻撃宣言ができない）を付与する。,[1]. If your opponent Normal Summons or Special Summons a monster; inflict 500 damage to all monsters on your opponent's field and grant them [Freeze (2 turns)]. ([Freeze] = Cannot attack.)
+[1].相手がモンスターを通常召喚・特殊召喚したとき発動できる。相手フィールド上のすべてのモンスターに500ポイントダメージを与え、「凍結」（２ターンの間、攻撃宣言ができない）を付与する。,[1]. If your opponent Summons a monster: Deal 500 damage to all monsters your opponent controls and they gain [Freeze (2 turns)]. (This monster cannot declare an attack.)

--- a/CSV/Language/English/Card/60006.txt
+++ b/CSV/Language/English/Card/60006.txt
@@ -1,3 +1,3 @@
 default
 魔術師見習いの杖,Apprentice Magician's Staff
-マスターに装備できる。このカードを装備している限り、魔法カードで相手に与えるダメージが常に100ポイントアップする。,Player use only.\n[1]. Your opponent receives 100 more damage from your Spell Cards.
+マスターに装備できる。このカードを装備している限り、魔法カードで相手に与えるダメージが常に100ポイントアップする。,Can only be equipped to yourself.\n[1]. The damage you inflict with Spell Cards is increased by 100.

--- a/CSV/Language/English/Card/60007.txt
+++ b/CSV/Language/English/Card/60007.txt
@@ -1,3 +1,3 @@
 default
 狩人のローブ,Hunter's Robe
-装備したモンスターは最大HPが300ポイントアップする。ハンタータイプのモンスターが装備した場合、さらに攻撃力を300ポイントアップする。,Equip on target monster and increase their Max HP by 300 points. If the monster is a Hunter Type; their power is also increased by 300 points.
+装備したモンスターは最大HPが300ポイントアップする。ハンタータイプのモンスターが装備した場合、さらに攻撃力を300ポイントアップする。,Can only be equipped to a monster. The equipped monsters gains 300 MAX HP. If the equipped monster is Hunter Type: The equipped monster gains 300 ATK.

--- a/CSV/Language/English/Card/60008.txt
+++ b/CSV/Language/English/Card/60008.txt
@@ -1,3 +1,3 @@
 default
 発掘シャベル,Excavation Shovel
-自分キャラクターに装備可能。装備者が戦闘で相手モンスターを破壊したとき、デッキからランダムに「ジェム」カードを1枚手札に加える。,Equip on target character. When the equipped character destroys an opponent's monster in battle; add a random "Gem" card from the deck to your hand.
+自分キャラクターに装備可能。装備者が戦闘で相手モンスターを破壊したとき、デッキからランダムに「ジェム」カードを1枚手札に加える。,Can only be equipped to a character you control. If the equipped character destroys a monster your opponent controls by battle: Add a random "Gem" card from your deck to your hand.


### PR DESCRIPTION

|Concept|Translation|Explanation|YGO source|
|--|--|--|--|
|Monster attack|ATK| Attack stat of a monster| https://yugipedia.com/wiki/Banner_of_Courage |
|Monster life| HP| Current life of a monster | N/A |
|Monster maximum life | MAX HP | | N/A |
|Your cards | Cards you control |  The cards that are on the player's field | https://yugipedia.com/wiki/Banner_of_Courage | 
|Enemy cards | Cards your opponent controls | The cards that are on your opponent's field | https://yugipedia.com/wiki/Burden_of_the_Mighty |
| Add a card from a location | Add a card to your hand from your [location] | For when the card isn't generated | https://yugipedia.com/wiki/Reinforcement_of_the_Army |
| Generate a card and add it to your hand | Add a card to your hand | If the location isn't specified, it means the card is generated| N/A|
| Increases its ATK/MAX HP by X | Gains X ATK/MAX HP | For any stat increase | https://yugipedia.com/wiki/Golden_Homunculus |
| Diminishes its ATK/MAX HP by X | Loses X ATK/MAX HP | For any stat loss | https://yugipedia.com/wiki/Burden_of_the_Mighty |
| Inflict [status] |  Gains [status] | When a card gains an ability of status, no matter if it is beneficial or not | https://gatherer.wizards.com/Pages/Card/Details.aspx?multiverseid=401880 |
| Inflicts X points of damage | Deal X damage | For damage dealing | https://gatherer.wizards.com/Pages/Card/Details.aspx?multiverseid=447286 |
|The Player| You | The person playing the card |  https://yugipedia.com/wiki/Darklord_Marie |
|Player's life | LP | Life Points |  https://yugipedia.com/wiki/Ancient_Fairy_Dragon |
| Activation requirements symbol | : | The symbol after the condition that needs to be true before you can "activate" the card (includes "Once Per Turn")|  https://yugipedia.com/wiki/Zombie_Master |
| Card cost symbol | ; (needs to be changed) | The symbol after the cost of the cards, that is, the thing you need to do before the effect can be used (can be canceled in-game) | https://yugipedia.com/wiki/Mezuki |
