### PR TITLE
Not Translateable: Refight text - Translated

### DIFF
--- a/CSV/Language/English/Other/Func.txt
+++ b/CSV/Language/English/Other/Func.txt
@@ -95,4 +95,12 @@ HP8000/Atk1300,Limit to HP8000/Atk1300
 画像閲覧,Artwork
 ドロー,Draw
 閉じる,Close
+闘技場バトル回想\n(イベントあり),Recall Arena Battle\n(with events)
+闘技場バトル回想\n(イベント省略),Recall Arena Battle\n(without events)
+イベントバトル回想\n(イベントあり),Recall Event Battle\n(with events)
+イベントバトル回想\n(イベント省略),Recall Event Battle\n(without events)
+街バトル回想\n(イベントあり),Recall Town Battle\n(with events)
+街ババトル回想\n(イベント省略),Recall Town Battle\n(without events)
+クエストバトル回想\n(イベントあり),Recall Quest Battle\n(with events)
+クエストバトル回想\n(イベント省略),Recall Quest Battle\n(without events)
 


### PR DESCRIPTION
Found the text responsible for the recollection matches under: Func's: @回想詳細ウインドウ画像表示.

Added a translation; not sure how good it is.

<img width="1358" height="539" alt="image" src="https://github.com/user-attachments/assets/bf14e26c-9c32-416a-8eac-24c0fb2e2286" />
